### PR TITLE
Chartboost: Remove Helium reward from partner API

### DIFF
--- a/ChartboostAdapter/src/main/java/com/chartboost/helium/chartboostadapter/ChartboostAdapter.kt
+++ b/ChartboostAdapter/src/main/java/com/chartboost/helium/chartboostadapter/ChartboostAdapter.kt
@@ -593,8 +593,7 @@ class ChartboostAdapter : PartnerAdapter {
                                 ad = event.ad,
                                 details = emptyMap(),
                                 request = request
-                            ),
-                            reward = Reward(event.reward, event.adID ?: "")
+                            )
                         )
                     }
                 },


### PR DESCRIPTION
Don't merge yet. Depends upon Bichen's upcoming Helium PR.