### PR TITLE
chore: bump adapter to 5.9.12.0.0 (Chartboost SDK 9.12.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ All official releases can be found on this repository's [releases page](https://
 
 ## Mediation 5
 
+### 5.9.12.0.0
+- This version of the adapter has been certified with Chartboost SDK 9.12.0.
+
 ### 5.9.11.1.0
 - This version of the adapter has been certified with Chartboost SDK 9.11.1.
 

--- a/ChartboostAdapter/build.gradle.kts
+++ b/ChartboostAdapter/build.gradle.kts
@@ -43,7 +43,7 @@ android {
         minSdk = 21
         targetSdk = 34
         // If you touch the following line, don't forget to update scripts/get_rc_version.zsh
-        android.defaultConfig.versionName = System.getenv("VERSION_OVERRIDE") ?: "5.9.11.1.0"
+        android.defaultConfig.versionName = System.getenv("VERSION_OVERRIDE") ?: "5.9.12.0.0"
         buildConfigField("String", "CHARTBOOST_MEDIATION_CHARTBOOST_ADAPTER_VERSION", "\"${android.defaultConfig.versionName}\"")
 
         consumerProguardFiles("proguard-rules.pro")
@@ -93,7 +93,7 @@ dependencies {
 
     // For external usage, please use the following production dependency.
     // You may choose a different release version.
-    implementation("com.chartboost:chartboost-sdk:9.11.1")
+    implementation("com.chartboost:chartboost-sdk:9.12.0")
 
     // Partner SDK Dependencies
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4")

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The Chartboost Mediation Chartboost adapter mediates Chartboost via the Chartboo
 
 In your `build.gradle`, add the following entry:
 ```
-    implementation "com.chartboost:chartboost-mediation-adapter-chartboost:5.9.11.1.0"
+    implementation "com.chartboost:chartboost-mediation-adapter-chartboost:5.9.12.0.0"
 ```
 
 ## Contributions


### PR DESCRIPTION
## Problem
ChartboostMonetization 9.12.0 shipped today; the Chartboost adapter was still pinned to 9.11.1.

## Approach
Standard release-prep bump matching past versions (cf. #96):
- Adapter `versionName`: `5.9.11.1.0` -> `5.9.12.0.0`
- `chartboost-sdk` dependency: `9.11.1` -> `9.12.0`
- CHANGELOG entry for `5.9.12.0.0`
- README integration snippet updated

## Why
Lets consumers pull the 9.12.0 SDK transitively via the adapter once a release is cut. Release tag/publish will be triggered via the auto-release GHA after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)