### PR TITLE
chore: bump adapter to 5.9.12.1.0 (Chartboost SDK 9.12.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ All official releases can be found on this repository's [releases page](https://
 
 ## Mediation 5
 
+### 5.9.12.1.0
+- This version of the adapter has been certified with Chartboost SDK 9.12.1.
+
 ### 5.9.12.0.0
 - This version of the adapter has been certified with Chartboost SDK 9.12.0.
 

--- a/ChartboostAdapter/build.gradle.kts
+++ b/ChartboostAdapter/build.gradle.kts
@@ -43,7 +43,7 @@ android {
         minSdk = 21
         targetSdk = 34
         // If you touch the following line, don't forget to update scripts/get_rc_version.zsh
-        android.defaultConfig.versionName = System.getenv("VERSION_OVERRIDE") ?: "5.9.12.0.0"
+        android.defaultConfig.versionName = System.getenv("VERSION_OVERRIDE") ?: "5.9.12.1.0"
         buildConfigField("String", "CHARTBOOST_MEDIATION_CHARTBOOST_ADAPTER_VERSION", "\"${android.defaultConfig.versionName}\"")
 
         consumerProguardFiles("proguard-rules.pro")
@@ -101,7 +101,7 @@ dependencies {
 
     // For external usage, please use the following production dependency.
     // You may choose a different release version.
-    implementation("com.chartboost:chartboost-sdk:9.12.0")
+    implementation("com.chartboost:chartboost-sdk:9.12.1")
 
     // Partner SDK Dependencies
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4")

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The Chartboost Mediation Chartboost adapter mediates Chartboost via the Chartboo
 
 In your `build.gradle`, add the following entry:
 ```
-    implementation "com.chartboost:chartboost-mediation-adapter-chartboost:5.9.12.0.0"
+    implementation "com.chartboost:chartboost-mediation-adapter-chartboost:5.9.12.1.0"
 ```
 
 ## Contributions


### PR DESCRIPTION
## Problem
Chartboost SDK 9.12.1 shipped today, but the adapter still pins 9.12.0, so Mediation integrators can't pick up the patch.

## Approach
Bump the adapter to 5.9.12.1.0 and the `chartboost-sdk` dependency 9.12.0 -> 9.12.1, with the CHANGELOG and README usage example updated to match. Mirrors the prior 5.9.12.0.0 bump (#98).

## Why
Keeps the adapter certified against the latest Monetization patch so mediation integrators get the 9.12.1 fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)